### PR TITLE
Release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2023-07-25)
+
+
+### Bug Fixes
+
+* clean command ([b7b149b](https://github.com/njfamirm/alwatr-community/commit/b7b149b502ec876069bb2bb5fdb1fe284678c1bb))
+* **container:** bash syntax ([7866f75](https://github.com/njfamirm/alwatr-community/commit/7866f753112a1c3d39c6d2e2298a7305ad62f67e))
+* **container:** use latest yarn command ([7e2d41b](https://github.com/njfamirm/alwatr-community/commit/7e2d41b69880539b8368f2c5a209e0908f762000))
+* **lerna:** change cuurrent version ([43b7f2a](https://github.com/njfamirm/alwatr-community/commit/43b7f2a608b661c74f5d3d690cab94edb8edcc64))
+* **lerna:** packages path ([b2191d0](https://github.com/njfamirm/alwatr-community/commit/b2191d02e8c00fe5cde0d46d2304d2c80501388e))
+* set correct field in package.json ([e837b3a](https://github.com/njfamirm/alwatr-community/commit/e837b3a6ac7a596f80ae6d2bc24f9aedc91f89ba))
+* versions ([4315d64](https://github.com/njfamirm/alwatr-community/commit/4315d643a5cb99703b80bb1047358b152c7ad742))
+* **workflow:** add coreect path for package ([5f8d643](https://github.com/njfamirm/alwatr-community/commit/5f8d6435e6a2f2b0d2d2324305447e4fdbe412ca))
+
+
+### Features
+
+* **cloud/alwatr:** add day countdown config ([b162faa](https://github.com/njfamirm/alwatr-community/commit/b162faa8518d877100c36f077ff41f2db580356d))
+* **cloud/lib:** copy deploy and manage script ([c130815](https://github.com/njfamirm/alwatr-community/commit/c13081551627171f498164d0f1a4ce7be9b3d8f6))
+* **day-countdown-bot:** copy package from alwatr ([088d051](https://github.com/njfamirm/alwatr-community/commit/088d051f25b929d13cc213894fba9fc5a27d0f14))
+* init from alwatr ([5287393](https://github.com/njfamirm/alwatr-community/commit/5287393d816953363a891869c87cfb61851df05c))
+* **telegram:** copy package from alwatr ([5f5aaab](https://github.com/njfamirm/alwatr-community/commit/5f5aaabc3eb0ea49b4a40d4aa63dc7847526b830))
+* **vscode:** support new yarn ([603b2a5](https://github.com/njfamirm/alwatr-community/commit/603b2a5a7a15689d18e333a0b4cf2116fa3b3d83))
+* **workflow:** build project outside of docker build ([00adf9b](https://github.com/njfamirm/alwatr-community/commit/00adf9be557b5de1dfe531f408e440a05f270aa4))
+* **yarn:** add workspace-tools plugin ([6f1172f](https://github.com/njfamirm/alwatr-community/commit/6f1172f5f3c814052d468b1f2823de5b11dbad9f))
+* **yarn:** upgrade to stable version ([ede494a](https://github.com/njfamirm/alwatr-community/commit/ede494aea8dd8d9bfb3e358e948fffb22a489de2))

--- a/core/telegram/CHANGELOG.md
+++ b/core/telegram/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2023-07-25)
+
+
+### Bug Fixes
+
+* set correct field in package.json ([e837b3a](https://github.com/njfamirm/alwatr-community/commit/e837b3a6ac7a596f80ae6d2bc24f9aedc91f89ba))
+* versions ([4315d64](https://github.com/njfamirm/alwatr-community/commit/4315d643a5cb99703b80bb1047358b152c7ad742))
+
+
+### Features
+
+* **telegram:** copy package from alwatr ([5f5aaab](https://github.com/njfamirm/alwatr-community/commit/5f5aaabc3eb0ea49b4a40d4aa63dc7847526b830))

--- a/core/telegram/package.json
+++ b/core/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alwatr-community/telegram",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Elegant micro telegram api.",
   "keywords": [
     "telegram",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "npmClient": "yarn",
   "packages": ["core/*", "uniquely/*"],
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,11 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "npmClient": "yarn",
-  "packages": ["core/*", "uniquely/*"],
+  "packages": [
+    "core/*",
+    "uniquely/*"
+  ],
   "command": {
     "version": {
       "conventionalCommits": true,
@@ -13,7 +16,9 @@
     },
     "publish": {
       "conventionalCommits": true,
-      "ignoreChanges": ["*.md"]
+      "ignoreChanges": [
+        "*.md"
+      ]
     },
     "run": {
       "stream": true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:ts": "eslint . --config .eslintrc.json --ext .ts",
     "build": "yarn build:ts",
     "build:ts": "tsc --build",
-    "build:r": "lerna run build",
+    "build:r": "yarn workspaces foreach run build",
     "format": "run-s format:prettier format:eslint",
     "format:eslint": "yarn lint:ts --fix",
     "format:prettier": "prettier . --ignore-path .gitignore --write",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "run-s format:prettier format:eslint",
     "format:eslint": "yarn lint:ts --fix",
     "format:prettier": "prettier . --ignore-path .gitignore --write",
-    "clean": "git clean -d -x -f --exclude=node_modulesy --exclude=_data",
+    "clean": "git clean -d -x -f --exclude=node_modules --exclude=_data",
     "serve": "wds",
     "watch": "run-p watch:* serve",
     "watch:ts": "yarn build:ts --watch --preserveWatchOutput",

--- a/uniquely/day-countdown-bot/CHANGELOG.md
+++ b/uniquely/day-countdown-bot/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2023-07-25)
+
+
+### Bug Fixes
+
+* set correct field in package.json ([e837b3a](https://github.com/njfamirm/alwatr-community/commit/e837b3a6ac7a596f80ae6d2bc24f9aedc91f89ba))
+* versions ([4315d64](https://github.com/njfamirm/alwatr-community/commit/4315d643a5cb99703b80bb1047358b152c7ad742))
+
+
+### Features
+
+* **day-countdown-bot:** copy package from alwatr ([088d051](https://github.com/njfamirm/alwatr-community/commit/088d051f25b929d13cc213894fba9fc5a27d0f14))

--- a/uniquely/day-countdown-bot/package.json
+++ b/uniquely/day-countdown-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alwatr-community/day-countdown-bot",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Alwatr Telegram Day Countdown Bot",
   "type": "module",
   "author": "S. Amir Mohammad Najafi <njfamirm@gmail.com> (https://njfamirm.ir)",
@@ -35,7 +35,7 @@
     "watch:es": "yarn build:es --watch"
   },
   "devDependencies": {
-    "@alwatr-community/telegram": "^0.0.0",
+    "@alwatr-community/telegram": "^0.1.0",
     "@alwatr/fetch": "^1.0.0",
     "@alwatr/i18n": "^1.0.0",
     "@alwatr/logger": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alwatr-community/day-countdown-bot@workspace:uniquely/day-countdown-bot"
   dependencies:
-    "@alwatr-community/telegram": ^0.0.0
+    "@alwatr-community/telegram": ^0.1.0
     "@alwatr/fetch": ^1.0.0
     "@alwatr/i18n": ^1.0.0
     "@alwatr/logger": ^1.0.0
@@ -87,7 +87,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@alwatr-community/telegram@^0.0.0, @alwatr-community/telegram@workspace:core/telegram":
+"@alwatr-community/telegram@^0.1.0, @alwatr-community/telegram@workspace:core/telegram":
   version: 0.0.0-use.local
   resolution: "@alwatr-community/telegram@workspace:core/telegram"
   dependencies:


### PR DESCRIPTION
# New Alwatr based project, for community 💎

community driven of Alwatr

## What's Changed
* feat(yarn): upgrade to stable version by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/7
* feat: copy day-countdown-bot and telegram from alwatr by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/8
* feat(vscode): support new yarn by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/9
* build(deps-dev): bump @typescript-eslint/parser from 6.1.0 to 6.2.0 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/6
* build(deps-dev): bump postcss from 8.4.26 to 8.4.27 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/5
* build(deps-dev): bump esbuild from 0.18.15 to 0.18.16 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/4
* build(deps-dev): bump postcss-preset-env from 9.0.0 to 9.1.0 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/1
* build(deps-dev): bump @types/node from 20.4.2 to 20.4.4 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/3
* build(deps-dev): bump @typescript-eslint/eslint-plugin from 6.1.0 to 6.2.0 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/2
* fix(workflow): add coreect path for package by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/10
* fix(workflow): yarn install by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/11
* feat(workflow): build project outside of docker build by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/12
* feat(cloud): add day countdown bot deployment config and script  by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/19
* fix: set correct field in package.json by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/20
* build(deps-dev): bump moment-jalaali from 0.9.6 to 0.10.0 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/16
* build(deps): bump tslib from 2.6.0 to 2.6.1 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/13
* build(deps): bump @alwatr/storage-engine from 0.30.0 to 1.0.1 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/17
* build(deps-dev): bump nodemon from 2.0.22 to 3.0.1 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/15
* build(deps): bump @alwatr/storage-client from 0.30.0 to 1.0.1 by @dependabot in https://github.com/njfamirm/alwatr-community/pull/14
* Release: v0.1.0 by @njfamirm in https://github.com/njfamirm/alwatr-community/pull/21

## New Contributors
* @njfamirm made their first contribution in https://github.com/njfamirm/alwatr-community/pull/7
* @dependabot made their first contribution in https://github.com/njfamirm/alwatr-community/pull/6

**Full Changelog**: https://github.com/njfamirm/alwatr-community/commits/v0.1.0